### PR TITLE
Added second-order synergy functions for 4D PID

### DIFF
--- a/infotheory/InfoTools.h
+++ b/infotheory/InfoTools.h
@@ -797,12 +797,12 @@ class InfoTools{
                 cerr << "For second order PID synergy, there needs to be at least 4 variables identified in varIDs using [0, 1, 2, 3]" << endl;
                 exit(1);
             }
+            double syn12 = 0.;
 
             if(multivariateDim == 4){
                 cerr << "For second order PID synergy, there needs to be at least 4 variables identified in varIDs using [0, 1, 2, 3]" << endl;
                 exit(1);
             }
-            double syn12 = 0.;
             else{
                 syn12 = synergy4Dsecondorder(varIDs);
             }

--- a/infotheory/PyLinker.cpp
+++ b/infotheory/PyLinker.cpp
@@ -104,4 +104,9 @@ extern "C"
         to_tvector_int(t_varIDs, varIDs);
         return PyFloat_FromDouble(it->synergy(t_varIDs));
     }
+    PyObject* synergy_order2_c_wrapper(InfoTools* it, PyObject* varIDs){
+        TVector<int> t_varIDs;
+        to_tvector_int(t_varIDs, varIDs);
+        return PyFloat_FromDouble(it->synergyorder2(t_varIDs));
+    }
 }

--- a/infotheory/infotools.py
+++ b/infotheory/infotools.py
@@ -241,3 +241,24 @@ class InfoTools(object):
         synergy_wrapper.argtypes = [c_void_p, py_object]
         synergy_wrapper.restype = c_double
         return synergy_wrapper(self._obj, list(var_IDs))
+
+    def synergy_second_order(self, var_IDs):
+        """ Compute second order synergistic information about a random var from two of three random vars for datapoints that have already been added in 4D PID.
+        The target random var is identified by varIDs==0
+        The sources are identified by varIDs==1 and varIDs==2 - varIDs==3 must be specified for calculation but is not classed as a source.
+        Set varIDs=-1 for dimensions to be ignored.
+
+        ARGS:
+        varIDs: (list-like, size=dims) list of length equal to dimensionality of data
+
+        RETURNS:
+        Synergistic information from vars defined by varIDs==1 and varIDs==2 about varIDs==0 in 4D PID.
+
+        Example:
+        if dims = 4, 4D datapoints will be added. If the first dimension denotes the target and the second and third denote the two sources, then set
+        varIDs = [0,1,2,3]
+        """
+        synergy_order2_wrapper = self.libc.synergy_order2_c_wrapper
+        synergy_order2_wrapper.argtypes = [c_void_p, py_object]
+        synergy_order2_wrapper.restype = c_double
+        return synergy_order2_wrapper(self._obj, list(var_IDs))

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@ long_description = """# Package for Mulativariate Information theoretic analyses
 https://github.com/madvn/infotheory"""
 
 # MacOS
-# export CXXFLAGS="-mmacosx-version-min=10.9"
-# export LDFLAGS="-mmacosx-version-min=10.9"
+export CXXFLAGS="-mmacosx-version-min=10.9"
+export LDFLAGS="-mmacosx-version-min=10.9"
 
 extra_compile_args = []
 if sys.platform == "darwin":

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,9 @@ long_description = """# Package for Mulativariate Information theoretic analyses
 https://github.com/madvn/infotheory"""
 
 # MacOS
-os.environ["CXXFLAGS"] = "-mmacosx-version-min=10.9"
+os.system('export CXXFLAGS="-mmacosx-version-min=10.9"')
+os.system('export LDFLAGS="-mmacosx-version-min=10.9"')
+
 os.environ["LDFLAGS"] = "-mmacosx-version-min=10.9"
 
 extra_compile_args = []

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@ long_description = """# Package for Mulativariate Information theoretic analyses
 https://github.com/madvn/infotheory"""
 
 # MacOS
-os.system('export CXXFLAGS="-mmacosx-version-min=10.9"')
-os.system('export LDFLAGS="-mmacosx-version-min=10.9"')
+# export CXXFLAGS="-mmacosx-version-min=10.9"
+# export LDFLAGS="-mmacosx-version-min=10.9"
 
 os.environ["LDFLAGS"] = "-mmacosx-version-min=10.9"
 

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@ long_description = """# Package for Mulativariate Information theoretic analyses
 https://github.com/madvn/infotheory"""
 
 # MacOS
-export CXXFLAGS="-mmacosx-version-min=10.9"
-export LDFLAGS="-mmacosx-version-min=10.9"
+os.environ["CXXFLAGS"] = "-mmacosx-version-min=10.9"
+os.environ["LDFLAGS"] = "-mmacosx-version-min=10.9"
 
 extra_compile_args = []
 if sys.platform == "darwin":


### PR DESCRIPTION
- Added some basic code to calculate the second order synergy atoms for 4-dimensional PID in a similar fashion to existing function for 'top' synergy of 4D PID.

- Some of the function added is redundant with existing synergy function, meaning that if you were to compute the top synergy and second order synergies at once, you would be repeating some of the same calculations. 

- Would be great to have an all-encompassing PID function in C++ that calculates all 18 atoms of the 4-dimensional PID in the same function to reduce this redundancy. This would be a lot quicker than using each function separately for each atom.
